### PR TITLE
fix allow pipelines to lazily create SourceRepository resources

### DIFF
--- a/knative-build-pipeline/templates/build-bot-role.yaml
+++ b/knative-build-pipeline/templates/build-bot-role.yaml
@@ -36,6 +36,7 @@ rules:
   - jenkins.io
   resources:
   - pipelineactivities
+  - sourcerepositories
   verbs:
   - get
   - create


### PR DESCRIPTION
usually they are already created; but just in case