### PR TITLE
fix: allow build pods to list/get services

### DIFF
--- a/tekton/templates/build-bot-role.yaml
+++ b/tekton/templates/build-bot-role.yaml
@@ -7,17 +7,12 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
+  - services
   verbs:
   - list
   - get
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - services
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
e.g. to find things like jenkins servers