### PR TITLE
chore: Upgrade Tekton to 0.5.1

### DIFF
--- a/tekton/templates/config-defaults.yaml
+++ b/tekton/templates/config-defaults.yaml
@@ -1,0 +1,39 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-timeout-minutes contains the default number of
+    # minutes to use for TaskRun, if none is specified.
+    default-timeout-minutes: "60"  # 60 minutes

--- a/tekton/values.yaml
+++ b/tekton/values.yaml
@@ -1,5 +1,5 @@
 image:
-  upstreamtag: v0.4.0
+  upstreamtag: v0.5.1
   kubeconfigwriter: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter
   credsinit: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init
   gitinit: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init


### PR DESCRIPTION
Needs https://github.com/jenkins-x/jx/pull/4664 in builders before
this will actually work.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>