### PR TITLE
chore: Add BDD test for installation of tekton chart to PR pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@ CHART_REPO := http://jenkins-x-chartmuseum:8080
 NAME := tekton
 OS := $(shell uname)
 
-CHARTMUSEUM_CREDS_USR := $(shell cat /builder/home/basic-auth-user.json)
-CHARTMUSEUM_CREDS_PSW := $(shell cat /builder/home/basic-auth-pass.json)
-
 init:
 	helm init --client-only
 
@@ -39,5 +36,8 @@ else
 	exit -1
 endif
 	helm package tekton
-	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(VERSION).tgz" $(CHART_REPO)/api/charts
+	curl --fail -u $(CHARTMUSEUM_USER):$(CHARTMUSEUM_PASS) --data-binary "@$(NAME)-$(VERSION).tgz" $(CHART_REPO)/api/charts
 	rm -rf ${NAME}*.tgz
+
+delete-from-chartmuseum:
+	curl --fail -u $(CHARTMUSEUM_USER):$(CHARTMUSEUM_PASS) -X DELETE $(CHART_REPO)/api/charts/$(NAME)/$(VERSION)

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -1,1 +1,95 @@
-buildPack: charts
+buildPack: none
+pipelineConfig:
+  pipelines:
+    pullRequest:
+      pipeline:
+        agent:
+          image: gcr.io/jenkinsxio/builder-go
+        options:
+          volumes:
+            - name: sa
+              secret:
+                secretName: bdd-secret
+                items:
+                  - key: bdd-credentials.json
+                    path: bdd/sa.json
+          containerOptions:
+            volumeMounts:
+              - mountPath: /secrets
+                name: sa
+        environment:
+          - name: GKE_SA
+            value: /secrets/bdd/sa.json
+          - name: GIT_COMMITTER_EMAIL
+            value: jenkins-x@googlegroups.com
+          - name: GIT_AUTHOR_EMAIL
+            value: jenkins-x@googlegroups.com
+          - name: GIT_AUTHOR_NAME
+            value: jenkins-x-bot
+          - name: GIT_COMMITTER_NAME
+            value: jenkins-x-bot
+          - name: BASE_WORKSPACE
+            value: /workspace/source
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
+          - name: PARALLEL_BUILDS
+            value: "2"
+          - name: GH_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-bot-test-github
+                key: password
+          - name: JENKINS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-jenkins-user
+                key: password
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
+        stages:
+          - name: build-and-bdd
+            steps:
+              - sh: make build
+                name: build
+              - name: bdd
+                sh: ./jx/bdd/ci.sh
+    release:
+      pipeline:
+        agent:
+          image: gcr.io/jenkinsxio/builder-go
+        environment:
+          - name: GIT_COMMITTER_EMAIL
+            value: jenkins-x@googlegroups.com
+          - name: GIT_AUTHOR_EMAIL
+            value: jenkins-x@googlegroups.com
+          - name: GIT_AUTHOR_NAME
+            value: jenkins-x-bot
+          - name: GIT_COMMITTER_NAME
+            value: jenkins-x-bot
+          - name: BASE_WORKSPACE
+            value: /workspace/source
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
+          - name: CHARTMUSEUM_USER
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_USER
+          - name: CHARTMUSEUM_PASS
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-chartmuseum
+                key: BASIC_AUTH_PASS
+        stages:
+          - name: release
+            steps:
+              - sh: make release
+                name: release

--- a/jx/bdd/README.md
+++ b/jx/bdd/README.md
@@ -1,0 +1,1 @@
+## BDD test of the Tekton chart using boot

--- a/jx/bdd/ci.sh
+++ b/jx/bdd/ci.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+export GH_USERNAME="jenkins-x-bot-test"
+export GH_EMAIL="jenkins-x@googlegroups.com"
+export GH_OWNER="jenkins-x-bot-test"
+
+export REPORTS_DIR="${BASE_WORKSPACE}/build/reports"
+export GINKGO_ARGS="-v"
+
+# fix broken `BUILD_NUMBER` env var
+export BUILD_NUMBER="$BUILD_ID"
+
+JX_HOME="/tmp/jxhome"
+KUBECONFIG="/tmp/jxhome/config"
+
+mkdir -p $JX_HOME
+
+jx --version
+jx step git credentials
+
+gcloud auth activate-service-account --key-file $GKE_SA
+
+# lets setup git 
+git config --global --add user.name JenkinsXBot
+git config --global --add user.email jenkins-x@googlegroups.com
+
+echo "running the BDD tests with JX_HOME = $JX_HOME"
+
+# setup jx boot parameters
+export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD"
+export JX_VALUE_PIPELINEUSER_USERNAME="$GH_USERNAME"
+export JX_VALUE_PIPELINEUSER_EMAIL="$GH_EMAIL"
+export JX_VALUE_PIPELINEUSER_TOKEN="$GH_ACCESS_TOKEN"
+export JX_VALUE_PROW_HMACTOKEN="$GH_ACCESS_TOKEN"
+
+# TODO temporary hack until the batch mode in jx is fixed...
+export JX_BATCH_MODE="true"
+
+# Release the snapshot chart
+make release
+
+git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
+cd boot-source
+cp ../jx/bdd/jx-requirements.yml .
+cp ../jx/bdd/parameters.yaml env
+sed -e s/\$VERSION/${VERSION}/g ../jx/bdd/helm-requirements.yaml.template > env/requirements.yaml
+
+
+# TODO hack until we fix boot to do this too!
+helm init --client-only
+helm repo add jenkins-x https://storage.googleapis.com/chartmuseum.jenkins-x.io
+
+set +e
+jx step bdd \
+    --versions-repo https://github.com/jenkins-x/jenkins-x-versions.git \
+    --config ../jx/bdd/cluster.yaml \
+    --gopath /tmp \
+    --git-provider=github \
+    --git-username $GH_USERNAME \
+    --git-owner $GH_OWNER \
+    --git-api-token $GH_ACCESS_TOKEN \
+    --default-admin-password $JENKINS_PASSWORD \
+    --tests test-verify-pods
+
+bdd_result=$?
+cd ..
+make delete-from-chartmuseum
+
+exit $bdd_result

--- a/jx/bdd/cluster.yaml
+++ b/jx/bdd/cluster.yaml
@@ -1,0 +1,18 @@
+clusters:
+  - name: boot-vault
+    args:
+      - create
+      - cluster
+      - gke
+      - --project-id=jenkins-x-bdd3
+      - -m=n1-standard-2
+      - --min-num-nodes=3
+      - --max-num-nodes=5
+      - -z=europe-west1-c
+      - --skip-login
+      - --skip-installation
+    commands:
+      - command: jx
+        args:
+          - boot
+          - -b

--- a/jx/bdd/helm-requirements.yaml.template
+++ b/jx/bdd/helm-requirements.yaml.template
@@ -1,0 +1,21 @@
+dependencies:
+  - name: jxboot-resources
+    repository: http://chartmuseum.jenkins-x.io
+  - alias: tekton
+    name: tekton
+    repository: http://chartmuseum.jenkins-x.io
+    version: $VERSION
+  - alias: prow
+    condition: prow.enabled
+    name: prow
+    repository: http://chartmuseum.jenkins-x.io
+  - alias: lighthouse
+    condition: lighthouse.enabled
+    name: lighthouse
+    repository: http://chartmuseum.jenkins-x.io
+  - alias: bucketrepo
+    condition: bucketrepo.enabled
+    name: bucketrepo
+    repository: http://chartmuseum.jenkins-x.io
+  - name: jenkins-x-platform
+    repository: http://chartmuseum.jenkins-x.io

--- a/jx/bdd/jx-requirements.yml
+++ b/jx/bdd/jx-requirements.yml
@@ -1,0 +1,43 @@
+gitops: true
+cluster:
+  clusterName: bdd-tekton-chart
+  environmentGitOwner: jenkins-x-bot-test
+  project: jenkins-x-bdd3
+  provider: gke
+  zone: europe-west1-c
+environments:
+  - key: dev
+    owner: ""
+    repository: ""
+  - key: staging
+    owner: ""
+    repository: ""
+  - key: production
+    owner: ""
+    repository: ""
+ingress:
+  domain: ""
+  externalDNS: false
+  tls:
+    email: ""
+    enabled: false
+    production: false
+kaniko: true
+secretStorage: vault
+storage:
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+webhook: prow
+vault:
+  disableURLDiscovery: true
+versionStream:
+  ref: "master"
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+

--- a/jx/bdd/parameters.yaml
+++ b/jx/bdd/parameters.yaml
@@ -1,0 +1,10 @@
+adminUser:
+  username: admin
+enableDocker: false
+gitProvider: github
+gpg: {}
+pipelineUser:
+  github:
+    host: github.com
+    username: jenkins-x-bot-test
+    email: jenkins-x@googlegroups.com


### PR DESCRIPTION
It just runs `test-verify-pods`, but the main thing is that we want to
make sure we can actually install the thing.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>