### PR TITLE
feat: Upgrade Tekton to v0.8.0

### DIFF
--- a/tekton/templates/200-clusterrole.yaml
+++ b/tekton/templates/200-clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
     resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns/finalizers", "pipelineruns/finalizers"]

--- a/tekton/templates/300-condition.yaml
+++ b/tekton/templates/300-condition.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2019 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,14 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: ConfigMap
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: config-artifact-pvc
-data:
-  # default size of the PVC mounted
-  size: "{{ .Values.pvc.size }}"
-
-  # storage class of the PVC volume
-  # storageClassName: storage-class-name
+  name: conditions.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Condition
+    plural: conditions
+    categories:
+      - all
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tekton/templates/300-imagecache.yaml
+++ b/tekton/templates/300-imagecache.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ConfigMap
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: config-artifact-pvc
-data:
-  # default size of the PVC mounted
-  size: "{{ .Values.pvc.size }}"
-
-  # storage class of the PVC volume
-  # storageClassName: storage-class-name
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/tekton/templates/clusterrole-aggregate-edit.yaml
+++ b/tekton/templates/clusterrole-aggregate-edit.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-aggregate-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tekton/templates/clusterrole-aggregate-view.yaml
+++ b/tekton/templates/clusterrole-aggregate-view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-aggregate-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - get
+  - list
+  - watch

--- a/tekton/templates/config-observability.yaml
+++ b/tekton/templates/config-observability.yaml
@@ -1,0 +1,53 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using Stackdriver will incur additional charges.
+    metrics.backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used and metrics will be sent to the cluster's project if this field is
+    # not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
+    # to send metrics to Stackdriver using "global" resource type and custom
+    # metric type. Setting this flag to "true" could cause extra Stackdriver
+    # charge.  If metrics.backend-destination is not Stackdriver, this is
+    # ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"

--- a/tekton/templates/controller.yaml
+++ b/tekton/templates/controller.yaml
@@ -11,16 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tekton.name" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "tekton.name" . }}
+    app.kubernetes.io/component: controller
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "tekton.name" . }}-controller
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ template "tekton.name" . }}-controller
+        app.kubernetes.io/name: {{ template "tekton.name" . }}
+        app.kubernetes.io/component: controller
     spec:
       serviceAccountName: {{ template "tekton.name" . }}
       containers:
@@ -37,13 +48,20 @@ spec:
           "-gsutil-image", "{{ .Values.image.gsutil }}:{{ .Values.image.upstreamtag }}",
           "-entrypoint-image", "{{ .Values.image.entrypoint }}:{{ .Values.image.upstreamtag }}",
           "-pr-image", "{{ .Values.image.pullrequest }}:{{ .Values.image.upstreamtag }}",
-          "-namespace", "{{ .Release.Namespace }}",
+          "-imagedigest-exporter-image", "{{ .Values.image.imagedigestexporter }}.{{ .Values.image.upstreamtag }}",
+          "-build-gcs-fetcher-image", "{{ .Values.image.gcsfetcher }}",
         ]
         env:
           - name: SYSTEM_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: CONFIG_LOGGING_NAME
+            value: config-logging
+          - name: CONFIG_OBSERVABILITY_NAME
+            value: config-observability
+          - name: METRICS_DOMAIN
+            value: tekton.dev/pipeline
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging

--- a/tekton/templates/webhook.yaml
+++ b/tekton/templates/webhook.yaml
@@ -13,16 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tekton.name" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "tekton.name" . }}
+    app.kubernetes.io/component: webhook-controller
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "tekton.name" . }}-webhook
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ template "tekton.name" . }}-webhook
+        app.kubernetes.io/name: {{ template "tekton.name" . }}
+        app.kubernetes.io/component: webhook-controller
     spec:
       serviceAccountName: {{ template "tekton.name" . }}
       containers:

--- a/tekton/values.yaml
+++ b/tekton/values.yaml
@@ -1,15 +1,17 @@
 image:
-  upstreamtag: v0.5.1
-  kubeconfigwriter: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter
-  credsinit: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init
-  gitinit: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init
-  nop: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop
-  bash: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/bash
-  gsutil: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/gsutil
-  controller: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller
-  webhook: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook
-  entrypoint: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint
-  pullrequest: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init
+  upstreamtag: 0.8.0-for-jx
+  kubeconfigwriter: gcr.io/abayer-pipeline-crd/tekton-for-jx/kubeconfigwriter
+  credsinit: gcr.io/abayer-pipeline-crd/tekton-for-jx/creds-init
+  gitinit: gcr.io/abayer-pipeline-crd/tekton-for-jx/git-init
+  nop: gcr.io/abayer-pipeline-crd/tekton-for-jx/nop
+  bash: gcr.io/abayer-pipeline-crd/tekton-for-jx/bash
+  gsutil: gcr.io/abayer-pipeline-crd/tekton-for-jx/gsutil
+  controller: gcr.io/abayer-pipeline-crd/tekton-for-jx/controller
+  webhook: gcr.io/abayer-pipeline-crd/tekton-for-jx/webhook
+  entrypoint: gcr.io/abayer-pipeline-crd/tekton-for-jx/entrypoint
+  pullrequest: gcr.io/abayer-pipeline-crd/tekton-for-jx/pullrequest-init
+  imagedigestexporter: gcr.io/abayer-pipeline-crd/tekton-for-jx/imagedigestexporter
+  gcsfetcher: gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.8.0
 auth:
   git:
     username:


### PR DESCRIPTION
part of https://github.com/jenkins-x/jx/issues/6317

Uses https://github.com/abayer/build-pipeline/tree/0.8.0-jx-support-backwards-incompats to deal with a few backwards incompatible changes - going forward, we'll want to update more frequently to avoid needing to fork.

Validation of `jx` using Tekton v0.5.1 to generate CRDs working with this chart is available in https://github.com/jenkins-x/jenkins-x-versions/pull/730
Validation of `jx` using Tekton v0.8.0 to generate CRDs working with this chart is available in https://github.com/jenkins-x/jx/pull/6382, though for the moment just pay attention to `boot-vault` - couldn't figure out how to get the `tekton` context to pick up a different chart version with `jx install` and decided it wasn't worth spending time on. =)