### PR TITLE
fix: Go back to just listening for events in our namespace

### DIFF
--- a/tekton/templates/controller.yaml
+++ b/tekton/templates/controller.yaml
@@ -50,6 +50,7 @@ spec:
           "-pr-image", "{{ .Values.image.pullrequest }}:{{ .Values.image.upstreamtag }}",
           "-imagedigest-exporter-image", "{{ .Values.image.imagedigestexporter }}.{{ .Values.image.upstreamtag }}",
           "-build-gcs-fetcher-image", "{{ .Values.image.gcsfetcher }}",
+          "-namespace", "{{ .Release.Namespace }}",
         ]
         env:
           - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
I...accidentally removed this line in
https://github.com/jenkins-x-charts/tekton/commit/cadb4f3d348bbdd834873d6f326ee893be2c9f09#diff-014537e7effd9783efb8b92333779f14. Not
my finest moment. =)

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>