### PR TITLE
fix: Support namespace-scoping again

### DIFF
--- a/jx/bdd/ci.sh
+++ b/jx/bdd/ci.sh
@@ -12,24 +12,33 @@ export GINKGO_ARGS="-v"
 # fix broken `BUILD_NUMBER` env var
 export BUILD_NUMBER="$BUILD_ID"
 
-JX_HOME="/tmp/jxhome"
-KUBECONFIG="/tmp/jxhome/config"
+# Release the snapshot chart
+make release
+
+export JX_HOME="/tmp/jxhome"
+export KUBECONFIG="/tmp/jxhome/config"
 
 mkdir -p $JX_HOME
 
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
 jx --version
-jx step git credentials
+
+mkdir -p $JX_HOME/git
+# replace the credentials file with a single user entry
+echo "https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com" > $JX_HOME/git/credentials
 
 gcloud auth activate-service-account --key-file $GKE_SA
 
-# lets setup git 
+# lets setup git
 git config --global --add user.name JenkinsXBot
 git config --global --add user.email jenkins-x@googlegroups.com
 
 echo "running the BDD tests with JX_HOME = $JX_HOME"
 
 # setup jx boot parameters
-export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD"
+export JX_VALUE_ADMINUSER_PASSWORD="$JENKINS_PASSWORD" # pragma: allowlist secret
 export JX_VALUE_PIPELINEUSER_USERNAME="$GH_USERNAME"
 export JX_VALUE_PIPELINEUSER_EMAIL="$GH_EMAIL"
 export JX_VALUE_PIPELINEUSER_TOKEN="$GH_ACCESS_TOKEN"
@@ -38,15 +47,17 @@ export JX_VALUE_PROW_HMACTOKEN="$GH_ACCESS_TOKEN"
 # TODO temporary hack until the batch mode in jx is fixed...
 export JX_BATCH_MODE="true"
 
-# Release the snapshot chart
-make release
-
+# Use the latest boot config promoted in the version stream instead of master to avoid conflicts during boot, because
+# boot fetches always the latest version available in the version stream.
+git clone  https://github.com/jenkins-x/jenkins-x-versions.git versions
+export BOOT_CONFIG_VERSION=$(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jenkins-x-boot-config --dir versions | sed 's/.*: \(.*\)/\1/')
 git clone https://github.com/jenkins-x/jenkins-x-boot-config.git boot-source
 cd boot-source
+git checkout tags/v${BOOT_CONFIG_VERSION} -b latest-boot-config
+
 cp ../jx/bdd/jx-requirements.yml .
 cp ../jx/bdd/parameters.yaml env
 sed -e s/\$VERSION/${VERSION}/g ../jx/bdd/helm-requirements.yaml.template > env/requirements.yaml
-
 
 # TODO hack until we fix boot to do this too!
 helm init --client-only
@@ -62,7 +73,10 @@ jx step bdd \
     --git-owner $GH_OWNER \
     --git-api-token $GH_ACCESS_TOKEN \
     --default-admin-password $JENKINS_PASSWORD \
-    --tests test-verify-pods
+    --no-delete-app \
+    --no-delete-repo \
+    --tests test-verify-pods \
+    --tests test-create-spring
 
 bdd_result=$?
 cd ..

--- a/tekton/templates/controller.yaml
+++ b/tekton/templates/controller.yaml
@@ -51,6 +51,7 @@ spec:
           "-pr-image", "{{ .Values.image.pullrequest }}:{{ .Values.image.upstreamtag }}",
           "-imagedigest-exporter-image", "{{ .Values.image.imagedigestexporter }}.{{ .Values.image.upstreamtag }}",
           "-build-gcs-fetcher-image", "{{ .Values.image.gcsfetcher }}",
+          "-namespace", "{{ .Release.Namespace }}",
         ]
         env:
           - name: SYSTEM_NAMESPACE

--- a/tekton/values.yaml
+++ b/tekton/values.yaml
@@ -1,5 +1,5 @@
 image:
-  upstreamtag: 0.8.0-for-jx
+  upstreamtag: v20200414-2b72e7c6
   kubeconfigwriter: gcr.io/abayer-pipeline-crd/tekton-for-jx/kubeconfigwriter
   credsinit: gcr.io/abayer-pipeline-crd/tekton-for-jx/creds-init
   gitinit: gcr.io/abayer-pipeline-crd/tekton-for-jx/git-init


### PR DESCRIPTION
Picks up https://github.com/abayer/tektoncd-pipeline/tree/0.8.0-ns-support - backporting a couple changes relating to context and injection and re-adding the namespace command line option for the controller.

cc @dgozalo 

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>