### PR TITLE
feat: disable the creation of CRDs and Cluster resources by values variables

### DIFF
--- a/tekton/templates/101-podsecuritypolicy.yaml
+++ b/tekton/templates/101-podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.resources.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,3 +40,4 @@ spec:
     ranges:
     - min: 1
       max: 65535
+{{- end -}}

--- a/tekton/templates/300-clustertask.yaml
+++ b/tekton/templates/300-clustertask.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/300-condition.yaml
+++ b/tekton/templates/300-condition.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2019 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/300-imagecache.yaml
+++ b/tekton/templates/300-imagecache.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,3 +34,4 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+{{- end -}}

--- a/tekton/templates/300-pipeline.yaml
+++ b/tekton/templates/300-pipeline.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/300-pipelinerun.yaml
+++ b/tekton/templates/300-pipelinerun.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/300-resource.yaml
+++ b/tekton/templates/300-resource.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/300-task.yaml
+++ b/tekton/templates/300-task.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/300-taskrun.yaml
+++ b/tekton/templates/300-taskrun.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster.crds.create }}
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+{{- end -}}

--- a/tekton/templates/clusterrole-aggregate-edit.yaml
+++ b/tekton/templates/clusterrole-aggregate-edit.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.cluster }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,3 +25,4 @@ rules:
   - patch
   - update
   - watch
+{{- end -}}

--- a/tekton/templates/clusterrole-aggregate-view.yaml
+++ b/tekton/templates/clusterrole-aggregate-view.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.cluster }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,3 +19,4 @@ rules:
   - get
   - list
   - watch
+{{- end -}}

--- a/tekton/values.yaml
+++ b/tekton/values.yaml
@@ -36,5 +36,11 @@ webhook:
 rbac:
   cluster: true
 
+cluster:
+  resources:
+    create: true
+  crds:
+    create: true
+
 pvc:
   size: 5Gi


### PR DESCRIPTION
Make the creation of CRDs and Cluster resources optional in order to install Tekton in two phases for cluster without cluster-wide permissions.