### PR TITLE
feat: allow a custom PVC storageClassName

### DIFF
--- a/tekton/templates/config-artifact-pvc.yaml
+++ b/tekton/templates/config-artifact-pvc.yaml
@@ -20,5 +20,7 @@ data:
   # default size of the PVC mounted
   size: "{{ .Values.pvc.size }}"
 
+  {{- if .Values.pvc.storageClassName }}
   # storage class of the PVC volume
-  # storageClassName: storage-class-name
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}

--- a/tekton/values.yaml
+++ b/tekton/values.yaml
@@ -44,3 +44,4 @@ cluster:
 
 pvc:
   size: 5Gi
+  storageClassName:


### PR DESCRIPTION
add a new value `pvc.storageClassName` to specify a custom storage class name for the PVC configmap